### PR TITLE
[Feat] OptaPlanner 도메인 설계 및 생성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,14 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	// OptaPlanner
+	implementation("org.optaplanner:optaplanner-core:9.44.0.Final")
+	implementation 'org.optaplanner:optaplanner-spring-boot-starter:9.44.0.Final' // 최신 버전 사용
+
+	// POI for Excel
+	implementation("org.apache.poi:poi:5.4.0")
+	implementation("org.apache.poi:poi-ooxml:5.4.0")
 }
 
 tasks.named('test') {

--- a/src/main/java/tave/auto_scheduling/config/OptaPlannerConfig.java
+++ b/src/main/java/tave/auto_scheduling/config/OptaPlannerConfig.java
@@ -1,0 +1,42 @@
+package tave.auto_scheduling.config;
+
+import org.optaplanner.core.api.solver.SolverFactory;
+import org.optaplanner.core.api.solver.SolverManager;
+import org.optaplanner.core.config.score.director.ScoreDirectorFactoryConfig;
+import org.optaplanner.core.config.solver.SolverConfig;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import tave.auto_scheduling.constraint.InterviewConstraintProvider;
+import tave.auto_scheduling.domain.ApplicantAssignment;
+import tave.auto_scheduling.domain.InterviewSchedule;
+
+import java.util.List;
+import java.util.UUID;
+
+@Configuration
+public class OptaPlannerConfig {
+
+    @Bean
+    public SolverConfig solverConfig() {
+        SolverConfig config = new SolverConfig();
+
+        config.setSolutionClass(InterviewSchedule.class);
+        config.setEntityClassList(List.of(ApplicantAssignment.class));
+        config.setScoreDirectorFactoryConfig(
+                new ScoreDirectorFactoryConfig()
+                        .withConstraintProviderClass(InterviewConstraintProvider.class)
+        );
+
+        return config;
+    }
+
+    @Bean
+    public SolverFactory<InterviewSchedule> solverFactory(SolverConfig solverConfig) {
+        return SolverFactory.create(solverConfig);
+    }
+
+    @Bean
+    public SolverManager<InterviewSchedule, UUID> solverManager(SolverFactory<InterviewSchedule> solverFactory) {
+        return SolverManager.create(solverFactory);
+    }
+}

--- a/src/main/java/tave/auto_scheduling/constraint/InterviewConstraintProvider.java
+++ b/src/main/java/tave/auto_scheduling/constraint/InterviewConstraintProvider.java
@@ -1,0 +1,12 @@
+package tave.auto_scheduling.constraint;
+
+import org.optaplanner.core.api.score.stream.Constraint;
+import org.optaplanner.core.api.score.stream.ConstraintFactory;
+import org.optaplanner.core.api.score.stream.ConstraintProvider;
+
+public class InterviewConstraintProvider implements ConstraintProvider {
+    @Override
+    public Constraint[] defineConstraints(ConstraintFactory constraintFactory) {
+        return new Constraint[0];
+    }
+}

--- a/src/main/java/tave/auto_scheduling/domain/Applicant.java
+++ b/src/main/java/tave/auto_scheduling/domain/Applicant.java
@@ -1,0 +1,35 @@
+package tave.auto_scheduling.domain;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/*
+* 면접 가능 시간 Excel에서 추출하는 지원자 기본 정보
+* 이름, 성별, 이메일, 지원 파트, 대학명, 면접 가능 시간
+* */
+
+@Getter
+@Builder
+public class Applicant {
+    private String name;
+    private String sex;
+    private String email;
+    private String part;
+    private String univ;
+    private List<LocalDateTime> availableSlots;
+
+    public Applicant of(String name, String sex, String email, String part, String univ, List<LocalDateTime> availableSlots) {
+        return Applicant.builder()
+                .name(name)
+                .sex(sex)
+                .email(email)
+                .part(part)
+                .univ(univ)
+                .availableSlots(availableSlots)
+                .build();
+    }
+
+}

--- a/src/main/java/tave/auto_scheduling/domain/ApplicantAssignment.java
+++ b/src/main/java/tave/auto_scheduling/domain/ApplicantAssignment.java
@@ -1,0 +1,54 @@
+package tave.auto_scheduling.domain;
+
+import lombok.Getter;
+import org.optaplanner.core.api.domain.entity.PlanningEntity;
+import org.optaplanner.core.api.domain.lookup.PlanningId;
+import org.optaplanner.core.api.domain.variable.PlanningVariable;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+/*
+* OptaPlanner가 최적화하는 핵심 대상
+* 하나의 지원자(Applicant)를 어떤 시간(InterviewSlot)에 배정할 지 결정하는 단위임.
+* @PlanningVariable를 통해서 OptaPlanner가 자동으로 최적의 InterviewSlot을 넣어줌.
+* */
+
+@Getter
+@PlanningEntity
+public class ApplicantAssignment {
+
+    @PlanningId
+    private String id;
+
+    private Applicant applicant;
+
+    @PlanningVariable(valueRangeProviderRefs = {"timeSlotRange"})
+    private InterviewSlot assignedSlot;
+
+    public ApplicantAssignment() {
+
+    }
+
+    public ApplicantAssignment(Applicant applicant) {
+        this.id = UUID.randomUUID().toString();
+        this.applicant = applicant;
+    }
+
+    // TODO 추가 개선 필요. 검증이 아닌 경우 대비
+    // Optaplanner가 배정한 시간이 지원자가 희망하는 면접시간대인지 검증함.
+    public void validAssignedTimeSlot() {
+        if (assignedSlot == null) {
+            System.out.println("==== Assigned slot is null ====");
+            return;
+        }
+
+        LocalDateTime assignedTime = assignedSlot.getTime();
+        boolean isValid = applicant.getAvailableSlots().contains(assignedTime);
+
+        if (!isValid) {
+            System.out.println(" Applicant Name " + applicant.getName() + " has incorrect time slot");
+        }
+    }
+
+}

--- a/src/main/java/tave/auto_scheduling/domain/InterviewSchedule.java
+++ b/src/main/java/tave/auto_scheduling/domain/InterviewSchedule.java
@@ -1,0 +1,39 @@
+package tave.auto_scheduling.domain;
+
+import lombok.Getter;
+import org.optaplanner.core.api.domain.solution.PlanningEntityCollectionProperty;
+import org.optaplanner.core.api.domain.solution.PlanningScore;
+import org.optaplanner.core.api.domain.solution.PlanningSolution;
+import org.optaplanner.core.api.domain.valuerange.ValueRangeProvider;
+import org.optaplanner.core.api.score.buildin.hardsoft.HardSoftScore;
+
+import java.util.List;
+
+/*
+* 전체 배정 결과를 저장하는 객체
+* @ValueRangeProvider는 면접 시간 전체 범위 (ex 08-10T10:00 ~ 08-13T17:00 이런 느낌)
+* @PlanningScore는 이 결과의 score를 나타냄. (최적화 정도. 높을 수록 좋음!)
+* score는 HARD, SOFT로 나뉨!
+ * */
+
+@Getter
+@PlanningSolution
+public class InterviewSchedule {
+    @ValueRangeProvider(id = "timeSlotRange")
+    private List<InterviewSlot> timeSlotList;
+
+    @PlanningEntityCollectionProperty
+    private List<ApplicantAssignment> assignmentList;
+
+    @PlanningScore
+    private HardSoftScore score;
+
+    public InterviewSchedule() {
+    }
+
+    public InterviewSchedule(List<InterviewSlot> timeSlotList, List<ApplicantAssignment> assignmentList) {
+        this.timeSlotList = timeSlotList;
+        this.assignmentList = assignmentList;
+    }
+
+}

--- a/src/main/java/tave/auto_scheduling/domain/InterviewSlot.java
+++ b/src/main/java/tave/auto_scheduling/domain/InterviewSlot.java
@@ -1,0 +1,23 @@
+package tave.auto_scheduling.domain;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+/*
+* 면접 가능 날짜 + 시간 단위를 나타냄.
+* @PlanningVariable, @ValueRangeProvider에서 사용하기 위해 객체화를 거침
+* */
+
+@Getter
+@Builder
+public class InterviewSlot {
+    private LocalDateTime time;
+
+    public InterviewSlot of(LocalDateTime time) {
+        return InterviewSlot.builder()
+                .time(time)
+                .build();
+    }
+}


### PR DESCRIPTION
## ➕ 연관된 이슈
> #1
> Close #1

## 📑 작업 내용
> - Optaplanner 도메인 설계

처음에는 Domain 객체만 설계하고자 했으나, Domain 객체만 설계하면 어플리케이션이 돌아가지 않아, Config를 비롯한 기타 Optaplanner 구성 객체들도 정의함. (아직은 빈 껍데기)

## Class
### Optaplanner Domain 객체 (관리 대상)
- Applicant
- ApplicantAssignment
- InterviewSchedule
- InterviewSlot

### Optaplanner 비지니스 객체 (문제 풀이)
- InterviewConstraintProvider
- InterviewScheduleSolver
- OptaPlannerConfig

<img width="690" height="700" alt="Optaplanner Domain 객체 구성" src="https://github.com/user-attachments/assets/5a4dee8d-12cf-433a-8a30-393657b759d3" />

### 예상 Optaplanner Flow

초기 예상 Flow!!

<img width="700" height="987" alt="OptaPlanner Flow" src="https://github.com/user-attachments/assets/510ff1df-a1ea-4668-a796-90e375afe5d8" />



## ✂️ 스크린샷 (선택)
>

