### PR TITLE
[Feat] Optaplanner 구성 객체 구현

### DIFF
--- a/src/main/java/tave/auto_scheduling/config/OptaPlannerConfig.java
+++ b/src/main/java/tave/auto_scheduling/config/OptaPlannerConfig.java
@@ -39,4 +39,5 @@ public class OptaPlannerConfig {
     public SolverManager<InterviewSchedule, UUID> solverManager(SolverFactory<InterviewSchedule> solverFactory) {
         return SolverManager.create(solverFactory);
     }
+
 }

--- a/src/main/java/tave/auto_scheduling/config/OptaPlannerSolverConfig.java
+++ b/src/main/java/tave/auto_scheduling/config/OptaPlannerSolverConfig.java
@@ -14,7 +14,7 @@ import java.util.List;
 import java.util.UUID;
 
 @Configuration
-public class OptaPlannerConfig {
+public class OptaPlannerSolverConfig {
 
     @Bean
     public SolverConfig solverConfig() {

--- a/src/main/java/tave/auto_scheduling/config/TerminateType.java
+++ b/src/main/java/tave/auto_scheduling/config/TerminateType.java
@@ -1,0 +1,15 @@
+package tave.auto_scheduling.config;
+
+/*
+* ONLY_HARD - Hard 조건만 충족하면 끝
+* OPTIMIZATION - 10초간 더 나은 해를 탐색, 최대 60초
+* HIGH_QUALITY - 20초간 더 나은 해를 탐색, 최대 60초, Hard 제약 보장,
+* */
+
+public enum TerminateType {
+
+    ONLY_HARD,
+    OPTIMIZATION,
+    HIGH_QUALITY
+
+}

--- a/src/main/java/tave/auto_scheduling/config/TerminationPolicyConfig.java
+++ b/src/main/java/tave/auto_scheduling/config/TerminationPolicyConfig.java
@@ -1,0 +1,31 @@
+package tave.auto_scheduling.config;
+
+import org.optaplanner.core.config.solver.termination.TerminationConfig;
+import org.springframework.context.annotation.Configuration;
+
+/*
+ * ONLY_HARD - Hard 조건만 충족하면 끝
+ * OPTIMIZATION - 10초간 더 나은 해를 탐색, 최대 60초
+ * HIGH_QUALITY - 20초간 더 나은 해를 탐색, 최대 60초, Hard 제약 보장,
+ * */
+
+@Configuration
+public class TerminationPolicyConfig {
+
+    public TerminationConfig provide(TerminateType type) {
+        return switch (type) {
+            case ONLY_HARD -> new TerminationConfig()
+                    .withBestScoreLimit("0hard/0soft")
+                    .withSecondsSpentLimit(60L)
+                    .withUnimprovedSecondsSpentLimit(10L);
+            case OPTIMIZATION -> new TerminationConfig()
+                    .withSecondsSpentLimit(60L)
+                    .withUnimprovedSecondsSpentLimit(10L);
+            case HIGH_QUALITY -> new TerminationConfig()
+                    .withBestScoreLimit("0hard/9999soft")
+                    .withSecondsSpentLimit(60L)
+                    .withUnimprovedSecondsSpentLimit(20L);
+        };
+    }
+
+}

--- a/src/main/java/tave/auto_scheduling/constraint/InterviewConstraintProvider.java
+++ b/src/main/java/tave/auto_scheduling/constraint/InterviewConstraintProvider.java
@@ -12,9 +12,12 @@ public class InterviewConstraintProvider implements ConstraintProvider {
     @Override
     public Constraint[] defineConstraints(ConstraintFactory factory) {
         return new Constraint[] {
+                mustBeAvailableSlot(factory),
                 maxThreePerSlot(factory),
                 limitDistinctParts(factory),
-                mustBeAvailableSlot(factory),
+                preferSamePartInSlot(factory),
+                preferFullInterviewSlots(factory),
+                bonusForSinglePartSlot(factory)
         };
     }
 
@@ -47,6 +50,34 @@ public class InterviewConstraintProvider implements ConstraintProvider {
                 .filter((slot, partSet) -> partSet.size() > 3)
                 .penalize(HardSoftScore.ONE_HARD, (slot, partSet) -> partSet.size() - 3)
                 .asConstraint("한 시간대에 허용된 파트 수(3개)를 초과");
+    }
+
+
+    // [Soft] 제약 1 - 같은 파트일수록 보상
+    private Constraint preferSamePartInSlot(ConstraintFactory factory) {
+        return factory.forEachUniquePair(ApplicantAssignment.class,
+                        Joiners.equal(ApplicantAssignment::getAssignedSlot))
+                .filter((a1, a2) -> !a1.getApplicant().getPart().equals(a2.getApplicant().getPart()))
+                .penalize(HardSoftScore.ONE_SOFT)
+                .asConstraint("같은 파트일수록 선호도 증가");
+    }
+
+    // [Soft] 제약 2- 한 면접 시간에 사람이 많을 수록 더 높은 선호도 (높은 점수를 부여함.) 단 하드 때문에 3명은 안넘음!
+    private Constraint preferFullInterviewSlots(ConstraintFactory factory) {
+        return factory.forEach(ApplicantAssignment.class)
+                .groupBy(ApplicantAssignment::getAssignedSlot, ConstraintCollectors.count())
+                .reward(HardSoftScore.ofSoft(2), (slot, count) -> count * count)
+                .asConstraint("한 시간대에 인원이 많을수록 선호도 증가");
+    }
+
+    // [Soft] 제약 3 - 같은 쌍만 있을 경우 가중치
+    private Constraint bonusForSinglePartSlot(ConstraintFactory factory) {
+        return factory.forEach(ApplicantAssignment.class)
+                .groupBy(ApplicantAssignment::getAssignedSlot,
+                        ConstraintCollectors.toSet(a -> a.getApplicant().getPart()))
+                .filter((slot, partSet) -> partSet.size() == 1)
+                .reward(HardSoftScore.ONE_SOFT)
+                .asConstraint("한 시간대에 동일 파트만 있으면 추가 보상");
     }
 
 }

--- a/src/main/java/tave/auto_scheduling/constraint/InterviewConstraintProvider.java
+++ b/src/main/java/tave/auto_scheduling/constraint/InterviewConstraintProvider.java
@@ -1,12 +1,52 @@
 package tave.auto_scheduling.constraint;
 
-import org.optaplanner.core.api.score.stream.Constraint;
-import org.optaplanner.core.api.score.stream.ConstraintFactory;
-import org.optaplanner.core.api.score.stream.ConstraintProvider;
+import org.optaplanner.core.api.score.buildin.hardsoft.HardSoftScore;
+import org.optaplanner.core.api.score.stream.*;
+import tave.auto_scheduling.domain.ApplicantAssignment;
+
+import java.time.LocalDateTime;
+import java.util.List;
 
 public class InterviewConstraintProvider implements ConstraintProvider {
+
     @Override
-    public Constraint[] defineConstraints(ConstraintFactory constraintFactory) {
-        return new Constraint[0];
+    public Constraint[] defineConstraints(ConstraintFactory factory) {
+        return new Constraint[] {
+                maxThreePerSlot(factory),
+                limitDistinctParts(factory),
+                mustBeAvailableSlot(factory),
+        };
     }
+
+    // [Hard] 제약 1 - 지원자가 지원한 시간에만 배정되어야 함
+    private Constraint mustBeAvailableSlot(ConstraintFactory factory) {
+        return factory.forEach(ApplicantAssignment.class)
+                .filter(assignment -> {
+                    LocalDateTime assignedTime = assignment.getAssignedSlot().getTime();
+                    List<LocalDateTime> available = assignment.getApplicant().getAvailableSlots();
+                    return !available.contains(assignedTime); // 가능한 시간에 포함되지 않으면 하드 패널티
+                })
+                .penalize(HardSoftScore.ONE_HARD)
+                .asConstraint("지원자가 선택하지 않은 시간에 배정");
+    }
+
+    // [Hard] 제약 2 - 한 시간에 3명 이하
+    private Constraint maxThreePerSlot(ConstraintFactory factory) {
+        return factory.forEach(ApplicantAssignment.class)
+                .groupBy(ApplicantAssignment::getAssignedSlot, ConstraintCollectors.count())
+                .filter((slot, count) -> count > 3)
+                .penalize(HardSoftScore.ONE_HARD, (slot, count) -> count - 3)
+                .asConstraint("시간대 최대 인원(3명)을 초과");
+    }
+
+    // [Hard] 제약 3 - 한 면접시간에 파트 종류 3개 이상 초과하면 X
+    private Constraint limitDistinctParts(ConstraintFactory factory) {
+        return factory.forEach(ApplicantAssignment.class)
+                .groupBy(ApplicantAssignment::getAssignedSlot,
+                        ConstraintCollectors.toSet(a -> a.getApplicant().getPart()))
+                .filter((slot, partSet) -> partSet.size() > 3)
+                .penalize(HardSoftScore.ONE_HARD, (slot, partSet) -> partSet.size() - 3)
+                .asConstraint("한 시간대에 허용된 파트 수(3개)를 초과");
+    }
+
 }

--- a/src/main/java/tave/auto_scheduling/domain/ApplicantAssignment.java
+++ b/src/main/java/tave/auto_scheduling/domain/ApplicantAssignment.java
@@ -1,6 +1,7 @@
 package tave.auto_scheduling.domain;
 
 import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
 import org.optaplanner.core.api.domain.entity.PlanningEntity;
 import org.optaplanner.core.api.domain.lookup.PlanningId;
 import org.optaplanner.core.api.domain.variable.PlanningVariable;
@@ -14,6 +15,7 @@ import java.util.UUID;
 * @PlanningVariable를 통해서 OptaPlanner가 자동으로 최적의 InterviewSlot을 넣어줌.
 * */
 
+@Slf4j
 @Getter
 @PlanningEntity
 public class ApplicantAssignment {
@@ -37,18 +39,20 @@ public class ApplicantAssignment {
 
     // TODO 추가 개선 필요. 검증이 아닌 경우 대비
     // Optaplanner가 배정한 시간이 지원자가 희망하는 면접시간대인지 검증함.
-    public void validAssignedTimeSlot() {
+    public boolean validAssignedTimeSlot() {
         if (assignedSlot == null) {
-            System.out.println("==== Assigned slot is null ====");
-            return;
+            return false;
         }
 
         LocalDateTime assignedTime = assignedSlot.getTime();
         boolean isValid = applicant.getAvailableSlots().contains(assignedTime);
 
         if (!isValid) {
-            System.out.println(" Applicant Name " + applicant.getName() + " has incorrect time slot");
+            log.info(" Applicant Name {} has incorrect time slot", applicant.getName());
+            return false;
         }
+
+        return true;
     }
 
 }

--- a/src/main/java/tave/auto_scheduling/domain/InterviewSlot.java
+++ b/src/main/java/tave/auto_scheduling/domain/InterviewSlot.java
@@ -15,7 +15,7 @@ import java.time.LocalDateTime;
 public class InterviewSlot {
     private LocalDateTime time;
 
-    public InterviewSlot of(LocalDateTime time) {
+    public static InterviewSlot of(LocalDateTime time) {
         return InterviewSlot.builder()
                 .time(time)
                 .build();

--- a/src/main/java/tave/auto_scheduling/provider/SolverManagerProvider.java
+++ b/src/main/java/tave/auto_scheduling/provider/SolverManagerProvider.java
@@ -1,0 +1,29 @@
+package tave.auto_scheduling.provider;
+
+import lombok.RequiredArgsConstructor;
+import org.optaplanner.core.api.solver.SolverManager;
+import org.optaplanner.core.config.solver.SolverConfig;
+import org.optaplanner.core.config.solver.termination.TerminationConfig;
+import org.springframework.context.annotation.Configuration;
+import tave.auto_scheduling.config.TerminateType;
+import tave.auto_scheduling.config.TerminationPolicyConfig;
+import tave.auto_scheduling.domain.InterviewSchedule;
+
+import java.util.UUID;
+
+@Configuration
+@RequiredArgsConstructor
+public class SolverManagerProvider {
+
+    private final SolverConfig solverConfig;
+    private final TerminationPolicyConfig terminationPolicyConfig;
+
+    public SolverManager<InterviewSchedule, UUID> createSolverManager(TerminateType type) {
+
+        TerminationConfig terminationConfig = terminationPolicyConfig.provide(type);
+        solverConfig.setTerminationConfig(terminationConfig);
+
+        return SolverManager.create(solverConfig);
+    }
+
+}

--- a/src/main/java/tave/auto_scheduling/solver/ScheduleSolver.java
+++ b/src/main/java/tave/auto_scheduling/solver/ScheduleSolver.java
@@ -1,0 +1,42 @@
+package tave.auto_scheduling.solver;
+
+import lombok.extern.slf4j.Slf4j;
+import org.optaplanner.core.api.solver.SolverJob;
+import org.optaplanner.core.api.solver.SolverManager;
+import org.springframework.stereotype.Service;
+import tave.auto_scheduling.domain.Applicant;
+import tave.auto_scheduling.domain.ApplicantAssignment;
+import tave.auto_scheduling.domain.InterviewSchedule;
+import tave.auto_scheduling.domain.InterviewSlot;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+public class ScheduleSolver {
+
+    public InterviewSchedule solve(List<InterviewSlot> timeSlots, List<Applicant> applicants, SolverManager<InterviewSchedule, UUID> solverManager) {
+
+        // TODO 고민 - List<Applicant> -> List<ApplicantAssignment>가 과연 Solver의 책임인가...?
+        List<ApplicantAssignment> assignmentList = applicants.stream()
+                .map(ApplicantAssignment::new)
+                .collect(Collectors.toList());
+
+        InterviewSchedule problem = new InterviewSchedule(timeSlots, assignmentList);
+
+        UUID problemId = UUID.randomUUID();
+        SolverJob<InterviewSchedule, UUID> solverJob = solverManager.solve(problemId, problem);
+
+        // 최종 최적해를 동기적으로 기다림.
+        try {
+            InterviewSchedule solution = solverJob.getFinalBestSolution();
+            return solution;
+        } catch (InterruptedException | ExecutionException e) {
+            throw new IllegalStateException("문제를 해결하지 못했습니다.", e);
+        }
+    }
+
+}

--- a/src/main/java/tave/auto_scheduling/solver/ScheduleSolver.java
+++ b/src/main/java/tave/auto_scheduling/solver/ScheduleSolver.java
@@ -35,6 +35,7 @@ public class ScheduleSolver {
 
             InterviewSchedule solution = solverJob.getFinalBestSolution();
             checkHardConstraint(solution);
+            isChosenTimeSlotByApplicant(solution);
 
             return solution;
         } catch (InterruptedException | ExecutionException e) {
@@ -45,6 +46,16 @@ public class ScheduleSolver {
     public void checkHardConstraint(InterviewSchedule solution) {
         if (solution.getScore().hardScore() < 0) {
             throw new IllegalStateException("하드 제약을 만족하는 해를 찾지 못했습니다.");
+        }
+    }
+
+    public void isChosenTimeSlotByApplicant(InterviewSchedule solution) {
+        List<ApplicantAssignment> assignmentList = solution.getAssignmentList();
+
+        for(ApplicantAssignment assignment : assignmentList) {
+            if (assignment.validAssignedTimeSlot()) {
+                throw new IllegalStateException("지원자가 희망하는 시간에 배정되지 않았습니다");
+            }
         }
     }
 

--- a/src/main/java/tave/auto_scheduling/solver/ScheduleSolver.java
+++ b/src/main/java/tave/auto_scheduling/solver/ScheduleSolver.java
@@ -32,10 +32,19 @@ public class ScheduleSolver {
 
         // 최종 최적해를 동기적으로 기다림.
         try {
+
             InterviewSchedule solution = solverJob.getFinalBestSolution();
+            checkHardConstraint(solution);
+
             return solution;
         } catch (InterruptedException | ExecutionException e) {
             throw new IllegalStateException("문제를 해결하지 못했습니다.", e);
+        }
+    }
+
+    public void checkHardConstraint(InterviewSchedule solution) {
+        if (solution.getScore().hardScore() < 0) {
+            throw new IllegalStateException("하드 제약을 만족하는 해를 찾지 못했습니다.");
         }
     }
 


### PR DESCRIPTION
## ➕ 연관된 이슈
> #3
> Close #3

## 📑 작업 내용
> - Optaplanner 구성 객체 구현

### 개선된 Flow 도식화

<img width="700" height="805" alt="Enhanced OptaPlanner Flow" src="https://github.com/user-attachments/assets/f7420567-436c-4be5-9fe7-060d8f128098" />

### Optaplanner 구성 객체 구현 & 개선

Optaplanner 구성 객체를 구현했습니다.
구현 중, Endpoint에 따른 다양한 종료 조건을 구현하고자 했습니다.
- 입력 Type에 따라 다양한 종료 조건을 반환하는 `TerminationPolicyConfig` Bean을 추가했습니다.   

- 기존의 `OptaPlannerConfig`는 `OptaPlannerSolverConfig`로 클래스명을 수정하여, Solver 관련 설정이라는 역할이 두드러지도록 했습니다.   

-  SolverManagerProvier는 `OptaPlannerSolverConfig`와 `TerminationPolicyConfig`를 주입 받아, Endpoint에 따른 적절한 SolverManager를 제공합니다.

### 사용 방법

ScheduleSolver를 주입 받아 solve() 메서드에 필요한 데이터와 적절한 SolverManager를 매개인자로 넘겨주면 `최적해 탐색`이 실행됩니다.



## ✂️ 스크린샷 (선택)
>

