### PR TITLE
Refactor #18 빈행이 마지막 행으로 인식되는 오류 수정

### DIFF
--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -1,4 +1,4 @@
-FROM openjdk:17
+FROM eclipse-temurin:17-jdk
 
 ARG JAR_FILE=build/libs/*.jar
 

--- a/src/main/java/tave/auto_scheduling/service/ExcelExportService.java
+++ b/src/main/java/tave/auto_scheduling/service/ExcelExportService.java
@@ -36,7 +36,7 @@ public class ExcelExportService {
             Sheet sheet = workbook.getSheetAt(0);
             Iterator<Row> rows = sheet.iterator();
             if (rows.hasNext()) rows.next(); // 헤더 스킵
-
+            int count = 0;
             while (rows.hasNext()) {
                 Row row = rows.next();
                 String name = getStringCellValue(row.getCell(0));
@@ -45,6 +45,11 @@ public class ExcelExportService {
                 String part = getStringCellValue(row.getCell(3));
                 String univ = getStringCellValue(row.getCell(4));
 
+                if (isRowEmpty(name, sex, email, part, univ)) continue;
+                count++;
+
+                log.info("name {}", name);
+                log.info("sex {}", sex);
                 log.info("part {}", part);
 
                 List<LocalDateTime> availableTimes = new ArrayList<>();
@@ -71,6 +76,7 @@ public class ExcelExportService {
 
                 applicants.add(Applicant.of(name, sex, email, part, univ, availableTimes));
             }
+            log.info("인식되는 행 개수 {}", count);
         } catch (IOException e) {
             throw new UncheckedIOException("[Excel]파일을 읽을 수 없습니다.", e);
         }
@@ -80,5 +86,12 @@ public class ExcelExportService {
 
     private String getStringCellValue(Cell cell) {
         return cell == null ? "" : cell.getCellType() == CellType.STRING ? cell.getStringCellValue() : cell.toString();
+    }
+
+    private boolean isRowEmpty(String... values) {
+        for (String value : values) {
+            if (!value.isBlank()) return false;
+        }
+        return true;
     }
 }


### PR DESCRIPTION
## ➕ 연관된 이슈
> #18 
> Close #18 

### 문제 상황

<img width="1760" height="298" alt="Image" src="https://github.com/user-attachments/assets/1c9ce54b-78c2-4388-8b68-0b8e1defc8f4" />

위처럼 눈으로는 데이터가 존재하지 않지만 `비어있는 행`이 데이터로 인식됨.
이로 인해 마지막 행이 122가 아닌 999번째로 인식되고 비어있는 면접 배정자가 877명이 생겨남

## 📑 작업 내용
> - 빈행이 마지막 행으로 인식되는 오류 수정

다음과 같이 하나의 Row에 데이터가 모두 empty인 경우는 Pass하도록 수정
- 모든 Cell 값이 비어있으면 수행하지 않도록 수정

```java
    if (isRowEmpty(name, sex, email, part, univ)) continue;

    private boolean isRowEmpty(String... values) {
        for (String value : values) {
            if (!value.isBlank()) return false;
        }
        return true;
    }
```

## 다른 대안

데이터가 존재하는 마지막 행을 계산하여, 반복문을 돌릴 수 있었음.
그러나 마지막 행을 판단하기 힘듦. 
데이터 중간에 비어있는 Row가 있을 수 도 있기 때문.
따라서 Row가 비어있으면 Pass하는 방식 선택

## ✂️ 스크린샷 (선택)
>

